### PR TITLE
Update sit_helper.py

### DIFF
--- a/cbm3_python/cbm3data/sit_helper.py
+++ b/cbm3_python/cbm3data/sit_helper.py
@@ -45,7 +45,9 @@ def mdb_xls_import(
     working_dir=None,
     toolbox_install_dir=None,
 ):
-
+    if not working_dir:
+        working_dir = os.path.dirname(os.path.abspath(imported_project_path))
+        
     config = get_sit_config(
         imported_project_path,
         mapping_path,


### PR DESCRIPTION
If working_dir was None, an error was raised during the function mdb_xls_import().
mdb_xls_import() -> config.import_project() -> path = os.fspath(path) -> TypeError: expected str, bytes or os.PathLike object, not NoneType